### PR TITLE
website copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ETHBerlin4 (2024) Website
+# ETHBerlin04 Website
 
-Join the ETHBerlin Matrix space to contribute: [https://matrix.to/#/#ethberlin:matrix.org](https://matrix.to/#/%23ethberlin:dod.ngo)
+Join the ETHBerlin Matrix space to contribute: [#ethberlin:dod.ngo](https://matrix.to/#/%23ethberlin:dod.ngo)
 
 # Run
 
@@ -25,4 +25,3 @@ Build with
 ```
 npm run build
 ```
-npx ga

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,9 +1,9 @@
 module.exports = {
   siteMetadata: {
-    title: "ETHBerlin4 2024",
+    title: "ETHBerlin04",
     siteUrl: `https://ethberlin.org`,
     url: `https://ethberlin.org`,
-    description: "ETHBerlin04: identity crisis, May 24-26, 2024, Kreuzberg, Berlin",
+    description: "ETHBerlin04: Identity Crisis, May 24-26, 2024, Kreuzberg, Berlin",
     twitterUsername: "@ETHBerlin",
     image: `/card.png`,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethberlin",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ethberlin",
-      "version": "1.0.0",
+      "version": "4.0.0",
       "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ethberlin",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "private": true,
-  "description": "ETHBerlin³ website",
+  "description": "ETHBerlin04 website",
   "author": "kuzdogan",
   "keywords": [
     "gatsby"

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,10 +17,6 @@ const Sidebar = ({ className }) => {
           <div>X</div>
         </button>
       )}
-      <a className="my-2" href="/about">
-        {" "}
-        &lt;&lt;a&lt;bout
-      </a>
       <a className="my-2" href="/manifesto">
         {" "}
         &lt;&lt;m&lt;anifesto
@@ -46,7 +42,7 @@ const Sidebar = ({ className }) => {
             join our{" "}
             <a
               className="underline"
-              href="https://matrix.to/#/%23ethberlin:matrix.org"
+              href="https://matrix.to/#/%23ethberlin:dod.ngo"
               target="_blank"
               rel="noreferrer"
             >
@@ -55,7 +51,7 @@ const Sidebar = ({ className }) => {
             &nbsp;or{" "}
             <a
               className="underline"
-              href="mailto:goerli@ethberlin.org"
+              href="mailto:contact@ethberlin.org"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/html.js
+++ b/src/html.js
@@ -18,9 +18,6 @@ export default function HTML(props) {
 
             function checkKey(e) {
                 e = e || window.event;
-                if (e.key == 'a' || e.key == 'A') {
-                    window.location.href= "/about";
-                }
                 else if (e.key == 'm' || e.key == 'M') {
                   window.location.href= "/manifesto";
                 }

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -18,12 +18,6 @@ const Impressum = () => {
                 <a href="mailto:contact@ethberlin.org">contact@ethberlin.org</a>{" "}
               </li>
               <li>
-                sponsors contact:{" "}
-                <a href="mailto:sponsors@ethberlin.org">
-                  sponsors@ethberlin.org
-                </a>{" "}
-              </li>
-              <li>
                 join our{" "}
                 <a href="https://matrix.to/#/%23ethberlin:dod.ngo">
                   matrix space
@@ -43,7 +37,7 @@ const Impressum = () => {
             Charlottenburg, Berlin, Umstatzsteuer-ID: DE325917754
           </div>
           <div className="mt-4">
-            Vertreten durch A. Schoedon, Telefon: +49 (0) 30 20613410, E-Mail:{" "}
+            Vertreten durch A. Schoedon, E-Mail:{" "}
             <a href="mailto:schoedon@ethberlin.org">schoedon@ethberlin.org</a>
           </div>
           <div className="mt-4">

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -33,7 +33,7 @@ const Home = () => {
                 alt="Fake passport image"
               />
             </div>
-            <p className="font-ocra my-0"> Event: ETHBerlin 4</p>
+            <p className="font-ocra my-0"> Event: ETHBerlin04</p>
             <p className="font-ocra my-0"> Theme: Identity Crisis</p>
             <p className="font-ocra my-0"> Dates: May 24-26, 2024</p>
           </p>
@@ -55,8 +55,8 @@ const Home = () => {
             years now. Established systems are failing, new and old imperialist
             powers are throwing continents into wars of attrition, global supply
             chains are collapsing, financial markets are tumbling, healthcare
-            systems are falling apart, education is on a consistent downward
-            spiral — the list goes on.
+            systems are falling apart, education is on a consistent downward
+            spiral — the list goes on.
           </p>
 
           <p>

--- a/src/pages/manifesto.jsx
+++ b/src/pages/manifesto.jsx
@@ -56,9 +56,9 @@ const Manifesto = () => {
               &quot;The folly was in thinking that, in a system that allows for
               almost anything, people would *not* maximize for their own utility
               over believing in the mission. To be fair though (and I mean this
-              very seriously) a lot of us aren’t exactly clear on *what* the
-              mission is. It seems like it’s mainly a lot of people trading
-              shitcoins and jpegs, but we’re told this isn’t what we’re trying
+              very seriously) a lot of us aren't exactly clear on *what* the
+              mission is. It seems like it's mainly a lot of people trading
+              shitcoins and jpegs, but we're told this isn't what we're trying
               to do.&quot;
             </p>
             <p>
@@ -115,7 +115,7 @@ const Manifesto = () => {
             </a>
             <em>
               &quot;The concept of proof-of-personhood in principle seems very
-              valuable [...]. A world with no proof-of-personhood seems more
+              valuable [...]. A world with no proof-of-personhood seems more
               likely to be a world dominated by centralized identity solutions,
               money, small closed communities, or some combination of all three.
             </em>
@@ -141,7 +141,7 @@ const Manifesto = () => {
           <p>
             We find ourselves at the intersection of decentralization, privacy
             and security research: zero-knowlegde cryptography, fully
-            homomorphic encryption, secure multi-party computation – the list
+            homomorphic encryption, secure multi-party computation — the list
             goes on. Let&#39;s put it to use!{" "}
           </p>
           <quote>
@@ -172,7 +172,7 @@ const Manifesto = () => {
           </p>
           <p>
             And, just like last year, we encourage hackers, workshop hosts, and
-            supporters at ETHBerlin 4 to focus on the following key attributes:
+            supporters at ETHBerlin04 to focus on the following key attributes:
           </p>
           <ul>
             <li>


### PR DESCRIPTION
- consistently use `ETHBerlin04` everywhere
- matrix space is officially on `:dod.ngo` now
- hiding the "About" site for now so that we can focus on the manifesto exclusively, we can unlock that later again
- removed phone number (and sponsors contact until we have a solution)