### PR TITLE
Fix padding and zindex on schedule sticky header

### DIFF
--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -436,7 +436,7 @@ const Program = () => {
           {/* Hacker Essentials vs Extravaganza */}
 
           <div
-            className={`flex items-center justify-center w-full sticky -top-1 py-4 text-center  ${
+            className={`flex items-center justify-center w-full sticky -top-1 py-4 text-center schedule-sticky ${
               isSticky ? "bg-white" : ""
             }`}
             ref={toggleRef}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -106,6 +106,12 @@
   @apply bg-[rgba(255,255,255,0.65)] p-6; /* Customize as needed */
 }
 
+
+.schedule-sticky {
+  width: calc(100% + 3rem);
+    margin-left: -1.5rem;
+    z-index: 2;
+}
 body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
@@ -178,7 +184,7 @@ body::before {
   }
 }
 
-/* 
+/*
 #__gatsby, #gatsby-focus-wrapper {
   height: 100vh; */
 /* background: url(grain-opacity.png), linear-gradient(5deg, #3A2F18 -25%, #0E0C06 15% ); */


### PR DESCRIPTION
The sticky header on the schedule page had a gap caused by the parent padding, and the icons overlapped when scrolling through the schedule. That was hurting my OCD, so I fixed it.

![dmp](https://github.com/ethb3rlin/4/assets/1190887/9db0b862-960f-41f6-9586-6da077754e46)
